### PR TITLE
fix getLinks

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ function getLinks(show, options, done) {
                 return;
             }
 
-            url = $(this).find('a[href^="/external"]').attr('href');
+            url = $(this).find('a[href^="/goto.php"]').attr('href');
             url = url.slice(url.indexOf('?') + 1);
             url = qs.parse(url).url;
             url = new Buffer(url, 'base64').toString();


### PR DESCRIPTION
Primewire changed their external url and was causing the getLinks method to fail.
